### PR TITLE
Update SLMetadataWriter.cpp

### DIFF
--- a/Source/USemLog/Private/SLMetadataWriter.cpp
+++ b/Source/USemLog/Private/SLMetadataWriter.cpp
@@ -96,7 +96,6 @@ void FSLMetadataWriter::WriteEnvironmentMetadata()
 	{
 		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.: %s"),
 			*FString(__func__), __LINE__, *FString(error.message));
-		bson_destroy(meta_doc);
 	}
 
 	// Clean up


### PR DESCRIPTION
Avoiding double-free when mongo collection insert fals